### PR TITLE
Swift 1.2 support

### DIFF
--- a/SpriteKit-Spring.swift
+++ b/SpriteKit-Spring.swift
@@ -237,7 +237,7 @@ extension SKAction {
 
             if initialValue == nil {
 
-                initialValue = node.valueForKeyPath(keyPath) as CGFloat
+                initialValue = node.valueForKeyPath(keyPath) as! CGFloat
                 initialDistance = initialDistance ?? finalValue - initialValue
                 finalValue = finalValue ?? initialValue + initialDistance
 


### PR DESCRIPTION
Fixes a breaking change in Swift 1.2 (`as!` for failable casts).
