### PR TITLE
Calculate distance correctly for animations using byValue

### DIFF
--- a/SpriteKit-Spring.podspec
+++ b/SpriteKit-Spring.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "SpriteKit-Spring"
-  s.version          = "1.0.1"
+  s.version          = "1.1.0"
   s.summary          = "SpriteKit API reproducing UIView's spring animations with SKAction"
   s.homepage         = "https://github.com/ataugeron/SpriteKit-Spring"
   s.screenshots     = "https://ataugeron.github.io/SpriteKit-Spring/bounce_1.gif", "https://ataugeron.github.io/SpriteKit-Spring/bounce_2.gif", "https://ataugeron.github.io/SpriteKit-Spring/bounce_3.gif"

--- a/SpriteKit-Spring.swift
+++ b/SpriteKit-Spring.swift
@@ -244,7 +244,7 @@ public extension SKAction {
             if initialValue == nil {
 
                 initialValue = node.value(forKeyPath: keyPath) as! CGFloat
-                initialDistance = initialDistance ?? finalValue - initialValue!
+                initialDistance = initialDistance != nil ? initialDistance * initialValue - initialValue : finalValue - initialValue!
                 finalValue = finalValue ?? initialValue! + initialDistance
 
                 var magicNumber: CGFloat! // picked manually to visually match the behavior of UIKit


### PR DESCRIPTION
Hey! Awesome library, thanks for building it. I noticed that there's a bug with animations that use `byValue`, e.g.:
```
SKAction.scale(by:duration:delay:usingSpringWithDamping:initialSpringVelocity:)
```

The distance isn't calculated correctly, so the behavior uses `byValue` as the distance.

For example, say there's a node with a current scale of 1.0 - if we tried to scale it by 1.2, SpriteKit-Spring will currently scale it to `1.0 + 1.2` instead of `1.0 * 1.2`, which in this case would more than double the scale instead of scaling appropariately. I put up an example app at [https://github.com/noahsark769/NGSpriteKitSpringTest](https://github.com/noahsark769/NGSpriteKitSpringTest) to demonstrate this.

The fix is to calculate the `initialDistance` based on multiplying it by `initialValue`.

Let me know if I need to do anything else to fix this bug! Thanks!